### PR TITLE
fix(security): patch 6 audit findings (HIGH NaN bypass, HIGH http default, +4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,15 @@ jobs:
       - run: npm ci
       - run: npx tsc --noEmit
       - run: npx vitest run tests/unit tests/integration
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: npm audit
+        run: npm audit --production --audit-level=high
+        continue-on-error: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solvela/sdk",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { ClientConfig, DEFAULT_CONFIG } from './config.js';
+import { ClientConfig, DEFAULT_CONFIG, validateGatewayUrl } from './config.js';
 import { Transport } from './transport.js';
 import { ResponseCache } from './cache.js';
 import { SessionStore } from './session.js';
@@ -21,8 +21,22 @@ import {
   RecipientMismatchError,
   AmountExceedsMaxError,
   InsufficientBalanceError,
+  SignerError,
 } from './errors.js';
-import { SOLANA_NETWORK } from './constants.js';
+import { SOLANA_NETWORK, USDC_MINT } from './constants.js';
+
+/**
+ * Parse a gateway-supplied atomic-amount string into a positive finite number.
+ * Throws SignerError if the value is not a finite positive integer — this
+ * prevents NaN/Infinity from silently bypassing the maxPaymentAmount cap.
+ */
+function parseAtomicAmount(raw: string): number {
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new SignerError(`Invalid payment amount: ${String(raw).slice(0, 32)}`);
+  }
+  return n;
+}
 
 export class SolvelaClient {
   private readonly config: ClientConfig;
@@ -39,6 +53,7 @@ export class SolvelaClient {
     signer?: Signer;
   }) {
     this.config = { ...DEFAULT_CONFIG, ...options?.config };
+    validateGatewayUrl(this.config.gatewayUrl);
     this.wallet = options?.wallet;
     this.signer = options?.signer;
     this.transport = new Transport(this.config.gatewayUrl, this.config.timeout);
@@ -244,7 +259,7 @@ export class SolvelaClient {
     // Validate payment
     this.validatePayment(accepted);
 
-    const amountAtomic = parseInt(accepted.maxAmountRequired, 10);
+    const amountAtomic = parseAtomicAmount(accepted.maxAmountRequired);
 
     // Balance guard
     if (this.lastBalance !== undefined && this.lastBalance < amountAtomic) {
@@ -293,7 +308,7 @@ export class SolvelaClient {
 
     this.validatePayment(accepted);
 
-    const amountAtomic = parseInt(accepted.maxAmountRequired, 10);
+    const amountAtomic = parseAtomicAmount(accepted.maxAmountRequired);
 
     if (this.lastBalance !== undefined && this.lastBalance < amountAtomic) {
       throw new InsufficientBalanceError(this.lastBalance, amountAtomic);
@@ -329,6 +344,20 @@ export class SolvelaClient {
   }
 
   private validatePayment(accepted: PaymentAccept): void {
+    // Network must be Solana mainnet — refuse to sign for any other chain.
+    if (accepted.network !== SOLANA_NETWORK) {
+      throw new ClientError(
+        `Unexpected payment network: ${String(accepted.network).slice(0, 64)}`,
+      );
+    }
+
+    // Asset (when supplied by the gateway) must be USDC mainnet mint.
+    if (accepted.asset !== undefined && accepted.asset !== USDC_MINT) {
+      throw new ClientError(
+        `Unexpected payment asset: ${String(accepted.asset).slice(0, 64)}`,
+      );
+    }
+
     if (
       this.config.expectedRecipient &&
       accepted.payTo !== this.config.expectedRecipient
@@ -336,7 +365,7 @@ export class SolvelaClient {
       throw new RecipientMismatchError(this.config.expectedRecipient, accepted.payTo);
     }
 
-    const amount = parseInt(accepted.maxAmountRequired, 10);
+    const amount = parseAtomicAmount(accepted.maxAmountRequired);
     if (this.config.maxPaymentAmount && amount > this.config.maxPaymentAmount) {
       throw new AmountExceedsMaxError(amount, this.config.maxPaymentAmount);
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,11 +13,19 @@ export interface ClientConfig {
   freeFallbackModel?: string;
 }
 
+/**
+ * Default cap on a single payment in USDC atomic units.
+ * 10 USDC (10_000_000 atomic with 6 decimals). Acts as a guardrail so the
+ * `maxPaymentAmount` cap is opt-out instead of opt-in.
+ */
+export const DEFAULT_MAX_PAYMENT_AMOUNT = 10_000_000;
+
 export const DEFAULT_CONFIG: ClientConfig = {
-  gatewayUrl: 'http://localhost:8402',
+  gatewayUrl: 'https://api.solvela.ai',
   rpcUrl: 'https://api.mainnet-beta.solana.com',
   preferEscrow: false,
   timeout: 180,
+  maxPaymentAmount: DEFAULT_MAX_PAYMENT_AMOUNT,
   enableCache: false,
   enableSessions: false,
   sessionTtl: 1800,
@@ -25,10 +33,35 @@ export const DEFAULT_CONFIG: ClientConfig = {
   maxQualityRetries: 1,
 };
 
+/**
+ * Reject plaintext `http://` gateway URLs unless the host is a loopback
+ * address. Prevents accidentally pointing the SDK at an unencrypted endpoint
+ * in production (where credentials and signed payment payloads would be
+ * exposed in transit).
+ */
+export function validateGatewayUrl(url: string): void {
+  if (url.startsWith('http://')) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error(`Invalid gatewayUrl: ${String(url).slice(0, 200)}`);
+    }
+    // URL.hostname wraps IPv6 in brackets — strip them before comparison.
+    const host = parsed.hostname.replace(/^\[/, '').replace(/\]$/, '');
+    if (host !== 'localhost' && host !== '127.0.0.1' && host !== '::1') {
+      throw new Error(
+        'gatewayUrl must use https:// for non-local endpoints (got http://)',
+      );
+    }
+  }
+}
+
 export class ClientBuilder {
   private config: ClientConfig = { ...DEFAULT_CONFIG };
 
   withGatewayUrl(url: string): ClientBuilder {
+    validateGatewayUrl(url);
     return this.with({ gatewayUrl: url });
   }
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -41,7 +41,7 @@ export class KeypairSigner implements Signer {
 
       const tx = new Transaction({ recentBlockhash: blockhash, feePayer: sender });
       tx.add(ix);
-      tx.sign(this.wallet.getKeypair());
+      this.wallet.signTransaction(tx);
 
       const txB64 = tx.serialize().toString('base64');
 

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,6 +1,16 @@
 import { ChatChunk, ChatRequest, ChatResponse, PaymentRequired } from './types.js';
 import { GatewayError, PaymentRequiredError, TimeoutError } from './errors.js';
 
+/**
+ * Strip control characters and truncate gateway-supplied error strings before
+ * surfacing them through Error messages. Prevents log injection / terminal
+ * escape attacks via attacker-controlled upstream error bodies.
+ */
+function sanitizeErrorMessage(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return String(s).replace(/[\r\n\x00-\x1f]/g, ' ').slice(0, 200);
+}
+
 export class Transport {
   constructor(
     private readonly baseUrl: string,
@@ -49,7 +59,10 @@ export class Transport {
         return PaymentRequired.fromJSON(await resp.json());
       } else {
         const data = (await resp.json().catch(() => ({}))) as Record<string, unknown>;
-        throw new GatewayError(resp.status, (data.error as string) || resp.statusText);
+        throw new GatewayError(
+          resp.status,
+          sanitizeErrorMessage((data.error as string) || resp.statusText),
+        );
       }
     } catch (e) {
       clearTimeout(timeoutId);
@@ -93,7 +106,10 @@ export class Transport {
     }
     if (resp.status !== 200) {
       const data = (await resp.json().catch(() => ({}))) as Record<string, unknown>;
-      throw new GatewayError(resp.status, (data.error as string) || resp.statusText);
+      throw new GatewayError(
+        resp.status,
+        sanitizeErrorMessage((data.error as string) || resp.statusText),
+      );
     }
 
     if (!resp.body) {
@@ -113,7 +129,22 @@ export class Transport {
         if (line.startsWith('data: ')) {
           const dataStr = line.slice(6).trim();
           if (dataStr === '[DONE]') return;
-          yield ChatChunk.fromJSON(JSON.parse(dataStr));
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(dataStr);
+          } catch (err) {
+            // Malformed SSE chunk from gateway — skip rather than crash the
+            // entire stream. Truncate the offending payload before logging
+            // so an attacker-controlled body cannot pollute logs.
+            // eslint-disable-next-line no-console
+            console.warn(
+              '[solvela] malformed SSE chunk, skipping:',
+              sanitizeErrorMessage(dataStr),
+              (err as Error).message,
+            );
+            continue;
+          }
+          yield ChatChunk.fromJSON(parsed);
         }
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -327,10 +327,11 @@ export class PaymentAccept {
     public readonly mimeType: string,
     public readonly payTo: string,
     public readonly extra: Record<string, unknown> = {},
+    public readonly asset?: string,
   ) {}
 
   toJSON(): Record<string, unknown> {
-    return {
+    return omitUndefined({
       scheme: this.scheme,
       network: this.network,
       max_amount_required: this.maxAmountRequired,
@@ -339,7 +340,8 @@ export class PaymentAccept {
       mime_type: this.mimeType,
       pay_to: this.payTo,
       extra: this.extra,
-    };
+      asset: this.asset,
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,6 +355,7 @@ export class PaymentAccept {
       data.mime_type,
       data.pay_to,
       data.extra ?? {},
+      data.asset,
     );
   }
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,4 +1,4 @@
-import { Keypair, PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey, Transaction, VersionedTransaction } from '@solana/web3.js';
 import * as bip39 from 'bip39';
 import bs58 from 'bs58';
 
@@ -6,6 +6,20 @@ import { WalletError } from './errors.js';
 
 export class Wallet {
   private constructor(private readonly keypair: Keypair) {}
+
+  /**
+   * Sign a Solana transaction (legacy or versioned) with the wallet's keypair.
+   * Prefer this over exposing the underlying Keypair through the public API —
+   * callers should never need a raw secret reference.
+   */
+  signTransaction<T extends Transaction | VersionedTransaction>(tx: T): T {
+    if (tx instanceof VersionedTransaction) {
+      tx.sign([this.keypair]);
+      return tx;
+    }
+    (tx as Transaction).sign(this.keypair);
+    return tx;
+  }
 
   static create(): [Wallet, string] {
     const mnemonic = bip39.generateMnemonic();
@@ -58,16 +72,22 @@ export class Wallet {
     return this.keypair.publicKey;
   }
 
+  /**
+   * @deprecated Returns the raw secret key bytes. Only use for backup/export
+   * to a secure store. Never log or transmit. Prefer `signTransaction` for
+   * signing flows so the secret never leaves the Wallet boundary.
+   */
   toKeypairBytes(): Uint8Array {
     return this.keypair.secretKey;
   }
 
+  /**
+   * @deprecated Returns the raw secret key in base58. Only use for
+   * backup/export to a secure store. Never log or transmit. Prefer
+   * `signTransaction` for signing flows.
+   */
   toKeypairB58(): string {
     return bs58.encode(this.keypair.secretKey);
-  }
-
-  getKeypair(): Keypair {
-    return this.keypair;
   }
 
   toString(): string {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { ClientBuilder, DEFAULT_CONFIG } from '../../src/config.js';
+import {
+  ClientBuilder,
+  DEFAULT_CONFIG,
+  DEFAULT_MAX_PAYMENT_AMOUNT,
+  validateGatewayUrl,
+} from '../../src/config.js';
 
 describe('DEFAULT_CONFIG', () => {
   it('has correct defaults', () => {
-    expect(DEFAULT_CONFIG.gatewayUrl).toBe('http://localhost:8402');
+    expect(DEFAULT_CONFIG.gatewayUrl).toBe('https://api.solvela.ai');
     expect(DEFAULT_CONFIG.rpcUrl).toBe('https://api.mainnet-beta.solana.com');
     expect(DEFAULT_CONFIG.preferEscrow).toBe(false);
     expect(DEFAULT_CONFIG.timeout).toBe(180);
@@ -13,16 +18,43 @@ describe('DEFAULT_CONFIG', () => {
     expect(DEFAULT_CONFIG.enableQualityCheck).toBe(false);
     expect(DEFAULT_CONFIG.maxQualityRetries).toBe(1);
     expect(DEFAULT_CONFIG.expectedRecipient).toBeUndefined();
-    expect(DEFAULT_CONFIG.maxPaymentAmount).toBeUndefined();
+    expect(DEFAULT_CONFIG.maxPaymentAmount).toBe(DEFAULT_MAX_PAYMENT_AMOUNT);
     expect(DEFAULT_CONFIG.freeFallbackModel).toBeUndefined();
+  });
+});
+
+describe('validateGatewayUrl', () => {
+  it('accepts https URLs', () => {
+    expect(() => validateGatewayUrl('https://api.solvela.ai')).not.toThrow();
+  });
+
+  it('accepts http for localhost', () => {
+    expect(() => validateGatewayUrl('http://localhost:8402')).not.toThrow();
+  });
+
+  it('accepts http for 127.0.0.1', () => {
+    expect(() => validateGatewayUrl('http://127.0.0.1:8402')).not.toThrow();
+  });
+
+  it('accepts http for [::1]', () => {
+    expect(() => validateGatewayUrl('http://[::1]:8402')).not.toThrow();
+  });
+
+  it('rejects http for non-loopback hosts', () => {
+    expect(() => validateGatewayUrl('http://example.com')).toThrow();
+    expect(() => validateGatewayUrl('http://api.solvela.ai')).toThrow();
   });
 });
 
 describe('ClientBuilder', () => {
   it('builds with defaults', () => {
     const config = new ClientBuilder().build();
-    expect(config.gatewayUrl).toBe('http://localhost:8402');
+    expect(config.gatewayUrl).toBe('https://api.solvela.ai');
     expect(config.timeout).toBe(180);
+  });
+
+  it('rejects insecure non-local gatewayUrl in builder', () => {
+    expect(() => new ClientBuilder().withGatewayUrl('http://evil.com')).toThrow();
   });
 
   it('supports fluent API', () => {

--- a/tests/unit/security_validation.test.ts
+++ b/tests/unit/security_validation.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SolvelaClient } from '../../src/client.js';
+import {
+  ChatRequest,
+  ChatMessage,
+  PaymentAccept,
+  PaymentRequired,
+} from '../../src/types.js';
+import { ClientError, SignerError, AmountExceedsMaxError } from '../../src/errors.js';
+import type { Signer } from '../../src/signer.js';
+import type { Resource } from '../../src/types.js';
+import { PaymentPayload, SolanaPayload } from '../../src/types.js';
+import { SOLANA_NETWORK, USDC_MINT } from '../../src/constants.js';
+
+/**
+ * Coverage for security audit fixes:
+ *  - HIGH-1  parseInt NaN bypass (validatePayment + handlePaymentRequired)
+ *  - NEW-HIGH validate network/asset/pay_to before signing
+ *  - HIGH-2  http:// gatewayUrl rejected for non-loopback hosts
+ */
+
+class StubSigner implements Signer {
+  public called = false;
+  async signPayment(
+    _amount: number,
+    _recipient: string,
+    _resource: Resource,
+    accepted: PaymentAccept,
+  ): Promise<PaymentPayload> {
+    this.called = true;
+    return new PaymentPayload(
+      2,
+      accepted.scheme,
+      accepted.network,
+      new SolanaPayload('fakeTx==', 'fakeSender'),
+    );
+  }
+}
+
+function pr(overrides: Partial<{
+  amount: string;
+  network: string;
+  asset?: string;
+  payTo: string;
+}>): Record<string, unknown> {
+  const accepted: Record<string, unknown> = {
+    scheme: 'exact',
+    network: overrides.network ?? SOLANA_NETWORK,
+    max_amount_required: overrides.amount ?? '1000000',
+    resource: 'https://example.com/v1/chat/completions',
+    description: 'Chat',
+    mime_type: 'application/json',
+    pay_to: overrides.payTo ?? '11111111111111111111111111111111',
+  };
+  if (overrides.asset !== undefined) accepted.asset = overrides.asset;
+  return {
+    x402_version: 2,
+    accepts: [accepted],
+    error: 'Payment required',
+  };
+}
+
+function mockFetchOnce(
+  status: number,
+  body: Record<string, unknown>,
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    status,
+    json: () => Promise.resolve(body),
+    body: null,
+    statusText: 'OK',
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('Security: parseAtomicAmount NaN guard', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects non-numeric maxAmountRequired', async () => {
+    mockFetchOnce(402, pr({ amount: 'free' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(SignerError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('rejects negative amount', async () => {
+    mockFetchOnce(402, pr({ amount: '-5' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(SignerError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('rejects zero amount', async () => {
+    mockFetchOnce(402, pr({ amount: '0' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(SignerError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('enforces default maxPaymentAmount cap (10 USDC atomic)', async () => {
+    // 11 USDC > 10 USDC default cap
+    mockFetchOnce(402, pr({ amount: '11000000' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(AmountExceedsMaxError);
+    expect(signer.called).toBe(false);
+  });
+});
+
+describe('Security: network/asset validation before signing', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('rejects unexpected network', async () => {
+    mockFetchOnce(402, pr({ network: 'evm:1' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(ClientError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('rejects unexpected asset (wrong mint)', async () => {
+    mockFetchOnce(402, pr({ asset: '11111111111111111111111111111111' }));
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+
+    await expect(client.chat(request)).rejects.toThrow(ClientError);
+    expect(signer.called).toBe(false);
+  });
+
+  it('accepts the correct USDC mint asset', async () => {
+    // First fetch returns 402 with correct asset; second is the post-signature retry.
+    let call = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        return Promise.resolve({
+          status: 402,
+          json: async () => pr({ asset: USDC_MINT }),
+          body: null,
+          statusText: 'Payment Required',
+        });
+      }
+      return Promise.resolve({
+        status: 200,
+        json: async () => ({
+          id: 'c1',
+          object: 'chat.completion',
+          created: 1,
+          model: 'gpt-4',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        body: null,
+        statusText: 'OK',
+      });
+    }) as unknown as typeof fetch;
+
+    const signer = new StubSigner();
+    const client = new SolvelaClient({ signer });
+    const request = new ChatRequest('gpt-4', [new ChatMessage('user', 'Hi')]);
+    const resp = await client.chat(request);
+    expect(signer.called).toBe(true);
+    expect(resp.choices[0].message.content).toBe('ok');
+  });
+});
+
+describe('Security: HTTP gateway URL validation', () => {
+  it('throws when constructing client with non-loopback http:// gateway', () => {
+    expect(
+      () => new SolvelaClient({ config: { gatewayUrl: 'http://evil.example.com' } }),
+    ).toThrow();
+  });
+
+  it('allows http://localhost', () => {
+    expect(
+      () => new SolvelaClient({ config: { gatewayUrl: 'http://localhost:8402' } }),
+    ).not.toThrow();
+  });
+
+  it('allows https:// for any host', () => {
+    expect(
+      () => new SolvelaClient({ config: { gatewayUrl: 'https://api.solvela.ai' } }),
+    ).not.toThrow();
+  });
+});
+
+describe('Security: PaymentRequired wire-format includes asset', () => {
+  it('PaymentAccept.fromJSON preserves asset field', () => {
+    const data = pr({ asset: USDC_MINT });
+    const parsed = PaymentRequired.fromJSON(data);
+    expect(parsed.accepts[0].asset).toBe(USDC_MINT);
+  });
+
+  it('PaymentAccept.toJSON omits asset when undefined', () => {
+    const accept = new PaymentAccept(
+      'exact',
+      SOLANA_NETWORK,
+      '1000',
+      'r',
+      'd',
+      'application/json',
+      '11111111111111111111111111111111',
+    );
+    const json = accept.toJSON();
+    expect('asset' in json).toBe(false);
+  });
+});

--- a/tests/unit/transport_security.test.ts
+++ b/tests/unit/transport_security.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { Transport } from '../../src/transport.js';
+import { ChatRequest, ChatMessage } from '../../src/types.js';
+import { GatewayError } from '../../src/errors.js';
+
+/**
+ * Coverage for security audit fixes:
+ *  - MEDIUM-1: SSE JSON.parse must not crash the stream on malformed data
+ *  - LOW-1:    gateway error strings sanitized (CR/LF/control chars stripped, truncated)
+ */
+
+describe('Transport: SSE malformed chunk handling', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function makeSseBody(lines: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    const payload = lines.map((l) => `${l}\n\n`).concat(['data: [DONE]\n\n']);
+    return new ReadableStream({
+      start(controller) {
+        for (const line of payload) {
+          controller.enqueue(encoder.encode(line));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  it('skips malformed JSON chunks but yields valid ones', async () => {
+    const validChunk = JSON.stringify({
+      id: 'c1',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: 'gpt-4',
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: 'ok' },
+          finish_reason: null,
+        },
+      ],
+    });
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      body: makeSseBody([
+        'data: {not json',
+        `data: ${validChunk}`,
+      ]),
+      json: async () => ({}),
+      statusText: 'OK',
+    }) as unknown as typeof fetch;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const t = new Transport('http://localhost:8402');
+    const req = new ChatRequest('gpt-4', [new ChatMessage('user', 'hi')]);
+
+    const collected: string[] = [];
+    for await (const chunk of t.sendChatStream(req)) {
+      const c = chunk.choices[0]?.delta?.content;
+      if (c) collected.push(c);
+    }
+
+    expect(collected).toEqual(['ok']);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+describe('Transport: gateway error sanitization', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('strips CR/LF/control characters from gateway error messages', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 500,
+      json: async () => ({ error: 'oops\r\ninjected: badline\x07' }),
+      statusText: 'Internal Server Error',
+    }) as unknown as typeof fetch;
+
+    const t = new Transport('http://localhost:8402');
+    const req = new ChatRequest('gpt-4', [new ChatMessage('user', 'hi')]);
+
+    try {
+      await t.sendChat(req);
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(GatewayError);
+      const msg = (e as GatewayError).message;
+      expect(msg).not.toContain('\r');
+      expect(msg).not.toContain('\n');
+      expect(msg).not.toContain('\x07');
+      expect(msg).toContain('oops');
+    }
+  });
+
+  it('truncates excessively long gateway error messages', async () => {
+    const long = 'x'.repeat(1000);
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      status: 500,
+      json: async () => ({ error: long }),
+      statusText: 'Internal Server Error',
+    }) as unknown as typeof fetch;
+
+    const t = new Transport('http://localhost:8402');
+    const req = new ChatRequest('gpt-4', [new ChatMessage('user', 'hi')]);
+
+    try {
+      await t.sendChat(req);
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      expect((e as GatewayError).message.length).toBeLessThanOrEqual(200);
+    }
+  });
+});

--- a/tests/unit/wallet.test.ts
+++ b/tests/unit/wallet.test.ts
@@ -60,9 +60,24 @@ describe('Wallet', () => {
     expect(pk.toBase58()).toBe(wallet.address());
   });
 
-  it('getKeypair() returns internal keypair', () => {
+  it('signTransaction() signs a transaction with the wallet keypair', async () => {
+    const { Transaction, SystemProgram, PublicKey } = await import('@solana/web3.js');
     const [wallet] = Wallet.create();
-    const kp = wallet.getKeypair();
-    expect(kp.publicKey.toBase58()).toBe(wallet.address());
+    const tx = new Transaction({
+      recentBlockhash: '11111111111111111111111111111111',
+      feePayer: wallet.publicKey(),
+    });
+    tx.add(
+      SystemProgram.transfer({
+        fromPubkey: wallet.publicKey(),
+        toPubkey: new PublicKey('11111111111111111111111111111111'),
+        lamports: 1,
+      }),
+    );
+    const signed = wallet.signTransaction(tx);
+    expect(signed.signatures.length).toBeGreaterThan(0);
+    expect(signed.signatures[0].signature).not.toBeNull();
+    // Public address is recoverable from signed payload — the secret never leaves the Wallet.
+    expect(signed.feePayer?.toBase58()).toBe(wallet.address());
   });
 });


### PR DESCRIPTION
## Summary
Patches 6 findings from the security audit of `@solvela/sdk`.

| ID | Severity | Fix |
|---|---|---|
| HIGH-1 | High | `parseAtomicAmount()` rejects NaN / Infinity / `<= 0` so `maxPaymentAmount` cap can no longer be silently bypassed |
| HIGH-2 | High | Default `gatewayUrl` is now `https://api.solvela.ai`; `validateGatewayUrl()` rejects `http://` for any non-loopback host |
| NEW-HIGH | High | `validatePayment()` now rejects unexpected `network` / `asset` before signing; default `maxPaymentAmount` cap of 10 USDC atomic |
| MEDIUM-1 | Medium | SSE `JSON.parse` wrapped in try/catch — malformed chunks logged + skipped instead of crashing the stream |
| MEDIUM-2 | Medium | `Wallet.signTransaction()` added; `getKeypair()` removed from public API; `toKeypairBytes()` / `toKeypairB58()` marked `@deprecated` |
| LOW-1 | Low | Gateway error strings sanitized (strip CR/LF/control chars, truncate to 200 chars) before being attached to thrown `GatewayError` |
| CI | — | Added `npm audit --production --audit-level=high` as a required job |

## Files changed
- `src/client.ts` — `parseAtomicAmount`, network/asset checks, gateway URL validation in constructor
- `src/config.ts` — new default URL, `validateGatewayUrl`, `DEFAULT_MAX_PAYMENT_AMOUNT`
- `src/transport.ts` — `sanitizeErrorMessage`, guarded SSE parse
- `src/wallet.ts` — `signTransaction()`; deprecated raw-secret accessors
- `src/signer.ts` — uses `wallet.signTransaction()` instead of `wallet.getKeypair()`
- `src/types.ts` — `PaymentAccept.asset` optional field (matches gateway protocol)
- `.github/workflows/ci.yml` — added `audit` job

## Test plan
- [x] `npm test` — 124 passing, 3 live-skipped (unchanged), 18 new security tests
- [x] `npm run build` (`tsc`) — clean
- [x] `npx tsc --noEmit` — clean
- [x] New tests cover: NaN/negative/zero amount rejection, default cap enforcement, network/asset validation, http:// non-loopback rejection, IPv6 loopback acceptance, malformed SSE skip-with-warn, error sanitization (CR/LF stripping + length truncation), `Wallet.signTransaction()` round-trip
- [ ] Verify CI `audit` job passes once merged (currently flagged 4 vulns on `main` per push notice — orthogonal, not introduced by this PR)

## Breaking changes
- `Wallet.getKeypair()` removed from public API. Callers should switch to `wallet.signTransaction(tx)`. `KeypairSigner` updated.
- `DEFAULT_CONFIG.gatewayUrl` changed from `http://localhost:8402` → `https://api.solvela.ai`. Local dev should explicitly pass `gatewayUrl: 'http://localhost:8402'` (still allowed).
- `DEFAULT_CONFIG.maxPaymentAmount` defaults to `10_000_000` atomic (10 USDC). Set to `Number.MAX_SAFE_INTEGER` to opt out.