### PR TITLE
ci: add npm tag-triggered publish workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,76 @@
+name: Release to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+# Required permissions:
+# - contents: write -> needed for `gh release create`
+# - id-token: write -> needed for npm provenance attestation (OIDC)
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish @solvela/sdk to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          # registry-url drives the .npmrc that lets `npm publish`
+          # read NODE_AUTH_TOKEN from the env on the publish step.
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Publishing version: $PKG_VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test --if-present
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Publish to npm
+        # --provenance attests the build origin via OIDC (requires id-token: write
+        # and a public repo + public package — both true for solvela-ai/solvela-ts).
+        # --access public is required for scoped packages (@solvela/*) on the free tier.
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes "Published to npm: https://www.npmjs.com/package/@solvela/sdk/v/${GITHUB_REF_NAME#v}
+
+          Install:
+          \`\`\`
+          npm install @solvela/sdk@${GITHUB_REF_NAME#v}
+          \`\`\`
+
+          Build is attested via npm provenance (sigstore)."

--- a/package.json
+++ b/package.json
@@ -18,7 +18,16 @@
     "SECURITY.md"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solvela-ai/solvela-ts.git"
+  },
+  "homepage": "https://github.com/solvela-ai/solvela-ts#readme",
+  "bugs": {
+    "url": "https://github.com/solvela-ai/solvela-ts/issues"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release-npm.yml` — a tag-triggered publish workflow that runs on every `v*` tag push, builds and tests the package, publishes to npm with provenance attestation, and creates a GitHub Release linking the published version.

This is the npm twin of the `release-crates.yml` workflow that just shipped on `solvela-client`.

## Pre-flight findings

Inspected `package.json`, `tsconfig.json`, `.gitignore`, and existing CI before writing the workflow. Mostly clean — but two small gaps worth landing alongside the workflow:

- **Missing `repository` field in `package.json`** — npm's provenance verifier matches the published repository URL against the GitHub Actions workflow origin to attest the build came from the claimed repo. Without it, provenance attestation can fail or produce a weaker claim. Added `repository`, `homepage`, and `bugs` fields pointing at `solvela-ai/solvela-ts`.
- **`publishConfig.provenance = true`** — set so any local `npm publish` attempts also produce attestations when the token permits, not just CI. Belt-and-suspenders with the workflow's `--provenance` flag.

Otherwise clean: `prepublishOnly: npm run build` already exists, `files` correctly limits the publish payload to `dist/README.md/LICENSE/SECURITY.md` (no source, tests, or fixtures shipped), `publishConfig.access: public` already set, no existing `release-npm.yml` to conflict with.

## Required one-time setup

Add a repo secret named `NPM_TOKEN`:

1. Go to https://www.npmjs.com/settings/<your-user>/tokens
2. Generate a new token of type **Automation** (NOT Publish — Publish tokens require an OTP at runtime, which CI cannot provide)
3. Scope it to **Publish** permission, restricted to the `@solvela/sdk` package only
4. Add it as `NPM_TOKEN` under repo Settings → Secrets and variables → Actions

After that, future releases are zero-touch:

```bash
# bump version
npm version patch   # or minor/major

# push commit + tag
git push && git push --tags
```

The workflow detects the tag, verifies it matches `package.json` version, builds, tests, publishes with provenance, and creates the GitHub Release.

## Workflow design notes

- Triggers: `push: tags: ['v*']`
- Permissions: `contents: write` (for `gh release create`), `id-token: write` (required for npm provenance via OIDC)
- Node 20, `actions/setup-node@v4` with `registry-url` set so `NODE_AUTH_TOKEN` is wired into the autogenerated `.npmrc`
- Runs `npm test --if-present` then `npm run build --if-present` so both are gracefully optional but currently both run (vitest + tsc)
- Tag/version mismatch check up front — fails fast before publish if `git tag v0.2.1` was pushed but `package.json` still says `0.2.0`
- Provenance is enabled and will work: public repo + public package + GitHub-hosted runner = all preconditions for OIDC-based attestation

## Test plan

- [ ] Add `NPM_TOKEN` repo secret (Automation type, publish scope, restricted to `@solvela/sdk`)
- [ ] Bump `package.json` to `0.2.1` and tag `v0.2.1` to validate the workflow end-to-end
- [ ] Verify the published version on npmjs.com shows the green provenance badge
- [ ] Verify the GitHub Release was auto-created and links to the npm version