### PR TITLE
chore(ci): drop Node 18 — unblocks dependabot vite/vitest 4.x bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:integration": "vitest run tests/integration",
     "lint": "tsc --noEmit"
   },
-  "engines": { "node": ">=18" },
+  "engines": { "node": ">=20.19" },
   "license": "MIT",
   "dependencies": {
     "@solana/web3.js": "^1.95",


### PR DESCRIPTION
## Summary

- Drops Node 18 from the CI matrix (was `[18, 20, 22]`, now `[20, 22]`)
- Bumps `engines.node` from `>=18` to `>=20.19` to match vite@8's requirement (`^20.19.0 || >=22.12.0`)

## Why

Node 18 reached End-of-Life on **April 30, 2025**. The two open dependabot PRs both require Node 20.19+ on the test runner:

- #2 — `chore(deps): bump esbuild and vitest` (vitest 2.x → 4.x)
- #3 — `chore(deps): bump vite and vitest` (vite 5.x → 8.x, vitest 2.x → 4.x)

Both PRs currently fail CI on the Node 18 job and pass on Node 20. Dropping 18 from the matrix unblocks them.

## Breaking change notice

This is **breaking for Node 18 consumers**: the next published version of `@solvela/sdk` (post-merge of #2 / #3) will fail to install on Node 18 with `EBADENGINE`. Consumers should upgrade to Node 20.19+ or stay on `@solvela/sdk@0.2.0`.

Justification: Node 18 has been EOL for ~12 months at this point; transitive deps (vite, esbuild, vitest) have already moved on.

## Dependabot alerts cleared after this lands + #2 + #3

| GHSA | Package | Severity | Cleared by |
|---|---|---|---|
| GHSA-67mh-4wv8-2f99 | esbuild | MEDIUM | #2 |
| GHSA-4w7w-66w2-5vf9 | vite | MEDIUM | #3 |

Remaining (transitive via `@solana/*`, not addressed here):
- `bigint-buffer` — HIGH
- `uuid` — MEDIUM

## Test plan

- [x] CI matrix passes on Node 20 + 22 for this branch
- [ ] After merge: `@dependabot rebase` on #2 → CI green → squash-merge
- [ ] After merge: `@dependabot rebase` on #3 → CI green → squash-merge
- [ ] Confirm 2 of 4 dependabot alerts close