### PR TITLE
release: bump to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@solvela/sdk",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@solana/spl-token": "^0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solvela/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeScript SDK for Solvela — Solana-native AI agent payment gateway",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps version 0.2.0 -> 0.2.1 in `package.json` and `package-lock.json`
- Cuts a fresh tag so `release-npm.yml` (added in #6) fires on a clean state
- v0.2.0 stays as the historical pre-publish tag

## Test plan
- [ ] Merge triggers no CI changes
- [ ] Tag `v0.2.1` push fires `release-npm.yml` workflow
- [ ] `@solvela/sdk@0.2.1` lands on npmjs.com with provenance attestation